### PR TITLE
Fixed API serializing the key instead of an empty string

### DIFF
--- a/src/Repositories/DefaultStringsRepository.php
+++ b/src/Repositories/DefaultStringsRepository.php
@@ -80,6 +80,9 @@ class DefaultStringsRepository
 
         foreach (array_keys($this->manager->getLocales()) as $locale) {
             $string = $translator->getCatalogue($locale)->get($key);
+            if ($string === $key) {
+                $string = null;
+            }
             $translation['locales'][$locale] = (string)$string;
         }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixed API serializing the key instead of an empty string (`ShowStringKeyController`), just as when listing all string keys (`StringKeyIndexController`)

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).