### PR TITLE
Add compatibility with flamarkt backoffice (for exports)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
                 "name": "fas fa-italic",
                 "backgroundColor": "#e74c3c",
                 "color": "#fff"
-            }
+            },
+            "optional-dependencies": [
+                "flamarkt/backoffice"
+            ]
         },
         "flagrow": {
             "discuss": "https://discuss.flarum.org/d/7026"

--- a/extend.php
+++ b/extend.php
@@ -10,6 +10,11 @@ return [
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js')
         ->css(__DIR__.'/resources/less/admin.less'),
+
+    (new Extend\Frontend('backoffice'))
+        ->js(__DIR__.'/js/dist/admin.js')
+        ->css(__DIR__.'/resources/less/admin.less'),
+
     new Extend\Locales(__DIR__ . '/resources/locale'),
     (new Extend\Routes('api'))
         ->get('/fof/linguist/string-keys', 'fof.linguist.api.string-keys.index', Controllers\StringKeyIndexController::class)


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds (optional) compatibility with flamarkt/backoffice so that another extension that used the Backoffice can still import modules coming from the Linguist admin frontend.

**Reviewers should focus on:**
Export work, nothing is broken.


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
