### PR TITLE
Always load and show English translations

### DIFF
--- a/js/src/admin/utils/localesAsArray.js
+++ b/js/src/admin/utils/localesAsArray.js
@@ -3,14 +3,32 @@ import app from 'flarum/admin/app';
 export default function () {
     let locales = [];
 
+    let englishFound = false;
+
     for (let key in app.data.locales) {
         if (!app.data.locales.hasOwnProperty(key)) {
             continue;
         }
 
+        if (key === 'en') {
+            englishFound = true;
+        }
+
         locales.push({
             key,
             name: app.data.locales[key],
+        });
+    }
+
+    // Always show English for the following reasons:
+    // It's the fallback locale, so the translations are always active
+    // It's the bundled locale for most extensions, so it makes sense to have access to it as reference
+    if (!englishFound) {
+        locales.unshift({
+            key: 'en',
+            // Hard-coded to the same value as in flarum/lang-english composer.json
+            // Since other locale names won't be translated to the current language either it doesn't make sense to use a translation
+            name: 'English',
         });
     }
 

--- a/src/Providers/LoadStrings.php
+++ b/src/Providers/LoadStrings.php
@@ -19,8 +19,16 @@ class LoadStrings extends AbstractServiceProvider
 
                 $translator->addLoader('fof_linguist', $this->container->make(StringLoader::class));
 
+                $localeKeys = array_keys($locales->getLocales());
+
+                // Even if English is not enabled, it's still used by Flarum as the fallback language
+                // So the loader must be added for custom English translations to apply when fallback is used
+                if (!in_array('en', $localeKeys)) {
+                    $localeKeys[] = 'en';
+                }
+
                 // Add the custom loader to every language available in Flarum
-                foreach ($locales->getLocales() as $locale => $name) {
+                foreach ($localeKeys as $locale) {
                     // The resource does not actually contain any data,
                     // it will be fetched from the database when the loader runs
                     $translator->addResource('fof_linguist', null, $locale);

--- a/src/Repositories/DefaultStringsRepository.php
+++ b/src/Repositories/DefaultStringsRepository.php
@@ -38,7 +38,7 @@ class DefaultStringsRepository
         // We disable our own translation loader so custom strings don't replace original ones
         TranslationLock::stopLoadingTranslations();
 
-        foreach (array_keys($this->manager->getLocales()) as $locale) {
+        foreach ($this->localeKeys() as $locale) {
             foreach (Arr::get($translator->getCatalogue($locale)->all(), 'messages', []) as $key => $string) {
                 if (!Arr::has($translations, $key)) {
                     $translations[$key] = [
@@ -78,7 +78,7 @@ class DefaultStringsRepository
 
         TranslationLock::stopLoadingTranslations();
 
-        foreach (array_keys($this->manager->getLocales()) as $locale) {
+        foreach ($this->localeKeys() as $locale) {
             $string = $translator->getCatalogue($locale)->get($key);
             if ($string === $key) {
                 $string = null;
@@ -89,5 +89,19 @@ class DefaultStringsRepository
         TranslationLock::continueLoadingTranslations();
 
         return $translation;
+    }
+
+    protected function localeKeys(): array
+    {
+        $locales = array_keys($this->manager->getLocales());
+
+        // Always include English, even if the language pack has been disabled or removed
+        // This is necessary to show translations that aren't included in any of the currently enabled langue packs
+        // The absence of the language pack doesn't cause any issue, all translations from core and its extensions are not in the language pack anyway
+        if (!in_array('en', $locales)) {
+            $locales[] = 'en';
+        }
+
+        return $locales;
     }
 }


### PR DESCRIPTION

**Changes proposed in this pull request:**

- Removes the need to enable English language pack to see all translations
- English is always visible as a reference even when it's not enabled

**Reviewers should focus on:**
This is a very straightforward change, I don't think there will be any debate, but I'll wait for a bit before merging.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
