### PR TITLE
Apply translations immediately in debug mode

### DIFF
--- a/js/src/admin/pages/StringsPage.js
+++ b/js/src/admin/pages/StringsPage.js
@@ -40,21 +40,7 @@ export default class StringsPage {
 
         return [
             // Additional divs are used to reduce Mithril redraws as much as possible when the conditional components appear
-            m('div', app.data.settings['fof.linguist.should-clear-cache'] === '1' ? Alert.component({
-                dismissible: false,
-                controls: [Button.component({
-                    className: 'Button Button--link',
-                    onclick() {
-                        // Same logic as in core StatusWidget
-                        app.modal.show(LoadingModal);
-
-                        app.request({
-                            method: 'DELETE',
-                            url: app.forum.attribute('apiUrl') + '/cache',
-                        }).then(() => window.location.reload());
-                    },
-                }, app.translator.trans('fof-linguist.admin.clear-cache.button'))],
-            }, app.translator.trans('fof-linguist.admin.clear-cache.text')) : null),
+            m('div', this.cacheClearInstructions()),
             m('.FoF-Linguist-Filters', [
                 m('input.FormControl', {
                     value: this.filters.search,
@@ -364,5 +350,35 @@ export default class StringsPage {
         });
 
         m.redraw();
+    }
+
+    cacheClearInstructions() {
+        // If debug is enabled, we hide the message here because even if we stop setting the flag,
+        // an older flag might still be present from before debug mode was enabled
+        if (app.data.debugEnabled) {
+            return null;
+        }
+
+        // Check for flag that says cache should be cleared
+        // This value is set both server-side and client-side in the onchange code above for immediate effect
+        if (app.data.settings['fof.linguist.should-clear-cache'] !== '1') {
+            return null;
+        }
+
+        return Alert.component({
+            dismissible: false,
+            controls: [Button.component({
+                className: 'Button Button--link',
+                onclick() {
+                    // Same logic as in core StatusWidget
+                    app.modal.show(LoadingModal);
+
+                    app.request({
+                        method: 'DELETE',
+                        url: app.forum.attribute('apiUrl') + '/cache',
+                    }).then(() => window.location.reload());
+                },
+            }, app.translator.trans('fof-linguist.admin.clear-cache.button'))],
+        }, app.translator.trans('fof-linguist.admin.clear-cache.text'));
     }
 }

--- a/src/Api/Controllers/ImportController.php
+++ b/src/Api/Controllers/ImportController.php
@@ -3,6 +3,7 @@
 namespace FoF\Linguist\Api\Controllers;
 
 use Flarum\Foundation\ValidationException;
+use FoF\Linguist\Repositories\CacheStatusRepository;
 use FoF\Linguist\Repositories\StringRepository;
 use FoF\Linguist\TextString;
 use Illuminate\Support\Arr;
@@ -17,10 +18,12 @@ use Symfony\Component\Yaml\Yaml;
 class ImportController implements RequestHandlerInterface
 {
     protected $repository;
+    protected $cacheStatus;
 
-    public function __construct(StringRepository $repository)
+    public function __construct(StringRepository $repository, CacheStatusRepository $cacheStatus)
     {
         $this->repository = $repository;
+        $this->cacheStatus = $cacheStatus;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -90,7 +93,7 @@ class ImportController implements RequestHandlerInterface
         }
 
         if ($totalImported > 0) {
-            $this->repository->cacheShouldBeCleared();
+            $this->cacheStatus->translationWasModified($locale);
         }
 
         return new JsonResponse([

--- a/src/Listeners/ClearCacheStatus.php
+++ b/src/Listeners/ClearCacheStatus.php
@@ -2,21 +2,19 @@
 
 namespace FoF\Linguist\Listeners;
 
-use Flarum\Foundation\Event\ClearingCache;
-use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Linguist\Repositories\CacheStatusRepository;
 
 class ClearCacheStatus
 {
-    protected $settings;
+    protected $cacheStatus;
 
-    public function __construct(SettingsRepositoryInterface $settings)
+    public function __construct(CacheStatusRepository $cacheStatus)
     {
-        $this->settings = $settings;
+        $this->cacheStatus = $cacheStatus;
     }
 
-    public function handle(ClearingCache $event)
+    public function handle()
     {
-        // When the cache has been cleared, either from Linguist tab or anywhere else, we remove our flag
-        $this->settings->delete('fof.linguist.should-clear-cache');
+        $this->cacheStatus->cacheWasCleared();
     }
 }

--- a/src/Repositories/CacheStatusRepository.php
+++ b/src/Repositories/CacheStatusRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace FoF\Linguist\Repositories;
+
+use Flarum\Foundation\Config;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class CacheStatusRepository
+{
+    protected $settings;
+    protected $config;
+
+    const SHOULD_CLEAR_SETTING_KEY = 'fof.linguist.should-clear-cache';
+    const LAST_EDIT_SETTING_KEY = 'fof.linguist.last-edit-date.';
+
+    public function __construct(SettingsRepositoryInterface $settings, Config $config)
+    {
+        $this->settings = $settings;
+        $this->config = $config;
+    }
+
+    /**
+     * To be called every time a customized translation is modified
+     * @param string|null $locale Locale that received updates or null for the special "all"
+     */
+    public function translationWasModified(string $locale = null): void
+    {
+        // No need to ask the user to clear cache if debug mode is on, the translations will be refreshed on next request already
+        if (!$this->config->inDebugMode()) {
+            // This flags lets the frontend know it should suggest to the user to clear the cache
+            $this->settings->set(self::SHOULD_CLEAR_SETTING_KEY, '1');
+        }
+
+        // Save the last edit date for use in the translator's isFresh logic
+        // Use one key per locale to reduce the performance impact in debug mode by only refreshing the locales that were modified
+        $this->settings->set(self::LAST_EDIT_SETTING_KEY . ($locale ?? 'all'), time());
+    }
+
+    /**
+     * To be called from an event listener for Flarum manual cache clear
+     */
+    public function cacheWasCleared(): void
+    {
+        // When the cache has been cleared, either from Linguist tab or anywhere else, we remove our flag
+        $this->settings->delete(self::SHOULD_CLEAR_SETTING_KEY);
+    }
+
+    /**
+     * Returns the date of last change to customized translations for the given locale, to be used in the translator freshness checker
+     * @param string $locale Locale key
+     * @return int UNIX timestamp
+     */
+    public function freshness(string $locale): int
+    {
+        // Cast to int will return 0 until a first translation is customized,
+        // This also covers older installations that have not made any change since updating Linguist
+        // where it will be read as up to date since the last translation timestamp will always be above zero
+        // We need to check both the current locale and the special "all" locale for updates
+        return max(
+            (int)$this->settings->get(self::LAST_EDIT_SETTING_KEY . $locale),
+            (int)$this->settings->get(self::LAST_EDIT_SETTING_KEY . 'all')
+        );
+    }
+}

--- a/src/Repositories/StringRepository.php
+++ b/src/Repositories/StringRepository.php
@@ -2,7 +2,6 @@
 
 namespace FoF\Linguist\Repositories;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Linguist\TextString;
 use FoF\Linguist\Validators\StringValidator;
 use Illuminate\Database\Eloquent\Model;
@@ -11,13 +10,13 @@ class StringRepository
 {
     protected $textString;
     protected $validator;
-    protected $settings;
+    protected $cacheStatus;
 
-    public function __construct(TextString $textString, StringValidator $validator, SettingsRepositoryInterface $settings)
+    public function __construct(TextString $textString, StringValidator $validator, CacheStatusRepository $cacheStatus)
     {
         $this->textString = $textString;
         $this->validator = $validator;
-        $this->settings = $settings;
+        $this->cacheStatus = $cacheStatus;
     }
 
     protected function query()
@@ -64,7 +63,7 @@ class StringRepository
         $string = new TextString($attributes);
         $string->save();
 
-        $this->cacheShouldBeCleared();
+        $this->cacheStatus->translationWasModified($string->locale);
 
         return $string;
     }
@@ -82,7 +81,7 @@ class StringRepository
         $string->fill($attributes);
         $string->save();
 
-        $this->cacheShouldBeCleared();
+        $this->cacheStatus->translationWasModified($string->locale);
 
         return $string;
     }
@@ -95,12 +94,6 @@ class StringRepository
     {
         $string->delete();
 
-        $this->cacheShouldBeCleared();
-    }
-
-    public function cacheShouldBeCleared()
-    {
-        // This flags lets the frontend know it should suggest to the user to clear the cache
-        $this->settings->set('fof.linguist.should-clear-cache', '1');
+        $this->cacheStatus->translationWasModified($string->locale);
     }
 }

--- a/src/Translator/DatabaseResource.php
+++ b/src/Translator/DatabaseResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FoF\Linguist\Translator;
+
+use FoF\Linguist\Repositories\CacheStatusRepository;
+use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
+
+class DatabaseResource implements SelfCheckingResourceInterface
+{
+    protected $locale;
+
+    public function __construct(string $locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function __toString(): string
+    {
+        // This is used as the resource identifier by the MessageCatalog
+        // We don't need it because there will only be one of these for a given catalog
+        return '';
+    }
+
+    public function isFresh(int $timestamp): bool
+    {
+        // Resolve status repository from container here so the translator doesn't try to serialize it including the database connection
+        return $timestamp > resolve(CacheStatusRepository::class)->freshness($this->locale);
+    }
+}

--- a/src/Translator/StringLoader.php
+++ b/src/Translator/StringLoader.php
@@ -36,6 +36,8 @@ class StringLoader implements LoaderInterface
 
         $catalog->add($messages);
 
+        $catalog->addResource(new DatabaseResource($locale));
+
         return $catalog;
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Apply changes immediately on next page load when debug mode is on, in the same way that yaml files do
- Remove cache clear banner in debug mode

This should have no impact in production mode since the freshness checks of the translator don't run at all in production mode.

**Reviewers should focus on:**
Do we really need this? I think it's a nice addition.

Initially I only wanted to remove the cache clear banner that I constantly see on my dev setup, but then I realized the translations were not applied immediately in debug mode. So I decided to implement it.

I decided to use a setting key to store the last edit timestamp rather than performing a database request to improve performance. I believe this code only runs in debug mode so it could also query the database directly for the last edits.

I'm not sure it could be done with checking the database directly at all, because there's no way to know when a string was deleted. It would require implementing soft-deletion or other history or hash-based update detection which would be more complicated than the proposed solution.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
