### PR TITLE
Add prefix filter (& permission to view string keys)

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -12,5 +12,18 @@ app.initializers.add('fof-linguist', app => {
     app.store.models['fof-linguist-string-key'] = StringKey;
     app.store.models['fof-linguist-string'] = TextString;
 
-    app.extensionData.for('fof-linguist').registerPage(LinguistPage);
+    app.extensionData
+        .for('fof-linguist')
+        .registerPage(LinguistPage)
+        .registerPermission(
+            {
+                icon: 'fas fa-italic',
+                label: app.translator.trans(
+                    'fof-linguist.admin.permissions.view_string_keys'
+                ),
+                permission: 'viewStringKeys',
+                allowGuest: true,
+            },
+            'view'
+        );
 });

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,5 +1,7 @@
 fof-linguist:
     admin:
+        permissions:
+            view_string_keys: View translation string keys
         tabs:
             strings: Translations
             coverage: Coverage

--- a/src/Api/Controllers/ExportController.php
+++ b/src/Api/Controllers/ExportController.php
@@ -2,6 +2,7 @@
 
 namespace FoF\Linguist\Api\Controllers;
 
+use Flarum\Http\RequestUtil;
 use Flarum\Locale\Translator;
 use FoF\Linguist\TextString;
 use Illuminate\Support\Arr;
@@ -23,7 +24,7 @@ class ExportController implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         $locale = Arr::get($request->getQueryParams(), 'locale', 'en');
 

--- a/src/Api/Controllers/ImportController.php
+++ b/src/Api/Controllers/ImportController.php
@@ -3,6 +3,7 @@
 namespace FoF\Linguist\Api\Controllers;
 
 use Flarum\Foundation\ValidationException;
+use Flarum\Http\RequestUtil;
 use FoF\Linguist\Repositories\CacheStatusRepository;
 use FoF\Linguist\Repositories\StringRepository;
 use FoF\Linguist\TextString;
@@ -28,7 +29,7 @@ class ImportController implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         $locale = Arr::get($request->getParsedBody(), 'locale', 'en');
 

--- a/src/Api/Controllers/ShowStringKeyController.php
+++ b/src/Api/Controllers/ShowStringKeyController.php
@@ -23,7 +23,7 @@ class ShowStringKeyController extends AbstractShowController
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        RequestUtil::getActor($request)->assertAdmin();
+        RequestUtil::getActor($request)->assertCan('viewStringKeys');
 
         $key = Arr::get($request->getQueryParams(), 'key');
 

--- a/src/Api/Controllers/StringDeleteController.php
+++ b/src/Api/Controllers/StringDeleteController.php
@@ -4,6 +4,7 @@ namespace FoF\Linguist\Api\Controllers;
 
 use FoF\Linguist\Repositories\StringRepository;
 use Flarum\Api\Controller\AbstractDeleteController;
+use Flarum\Http\RequestUtil;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,7 +19,7 @@ class StringDeleteController extends AbstractDeleteController
 
     protected function delete(ServerRequestInterface $request)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         $id = Arr::get($request->getQueryParams(), 'id');
 

--- a/src/Api/Controllers/StringIndexController.php
+++ b/src/Api/Controllers/StringIndexController.php
@@ -5,6 +5,7 @@ namespace FoF\Linguist\Api\Controllers;
 use FoF\Linguist\Api\Serializers\StringSerializer;
 use FoF\Linguist\Repositories\StringRepository;
 use Flarum\Api\Controller\AbstractListController;
+use Flarum\Http\RequestUtil;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -21,7 +22,7 @@ class StringIndexController extends AbstractListController
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         return $this->strings->all();
     }

--- a/src/Api/Controllers/StringKeyIndexController.php
+++ b/src/Api/Controllers/StringKeyIndexController.php
@@ -5,6 +5,7 @@ namespace FoF\Linguist\Api\Controllers;
 use FoF\Linguist\Api\Serializers\StringKeySerializer;
 use FoF\Linguist\Repositories\DefaultStringsRepository;
 use Flarum\Api\Controller\AbstractListController;
+use Flarum\Http\RequestUtil;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -31,16 +32,13 @@ class StringKeyIndexController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
+        RequestUtil::getActor($request)->assertCan('viewStringKeys');
+
         // Extract filters from the request.
         $filters = $this->extractFilter($request);
 
         // Look for the 'prefix' key in the filters.
         $prefix = Arr::get($filters, 'prefix', null);
-
-        // If no prefix is provided, ensure the requestor is an admin.
-        if (!$prefix) {
-            $request->getAttribute('actor')->assertAdmin();
-        }
 
         // Retrieve all translations from the repository.
         $all = $this->repository->allTranslations();

--- a/src/Api/Controllers/StringKeyIndexController.php
+++ b/src/Api/Controllers/StringKeyIndexController.php
@@ -5,6 +5,9 @@ namespace FoF\Linguist\Api\Controllers;
 use FoF\Linguist\Api\Serializers\StringKeySerializer;
 use FoF\Linguist\Repositories\DefaultStringsRepository;
 use Flarum\Api\Controller\AbstractListController;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -19,10 +22,38 @@ class StringKeyIndexController extends AbstractListController
         $this->repository = $repository;
     }
 
+    /**
+     * Retrieve and optionally filter translation string keys.
+     *
+     * @param ServerRequestInterface $request The server request containing filters.
+     * @param Document $document The document to store the translation data.
+     * @return Collection The collection of filtered translations.
+     */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        // Extract filters from the request.
+        $filters = $this->extractFilter($request);
 
-        return $this->repository->allTranslations();
+        // Look for the 'prefix' key in the filters.
+        $prefix = Arr::get($filters, 'prefix', null);
+
+        // If no prefix is provided, ensure the requestor is an admin.
+        if (!$prefix) {
+            $request->getAttribute('actor')->assertAdmin();
+        }
+
+        // Retrieve all translations from the repository.
+        $all = $this->repository->allTranslations();
+
+        // If a prefix is provided, filter the translations by that prefix.
+        if ($prefix) {
+            return $all->filter(function ($item) use ($prefix) {
+                // Return true if the item's key starts with the provided prefix.
+                return Str::startsWith($item['key'], $prefix);
+            });
+        } else {
+            // If no prefix is provided, return all translations.
+            return $all;
+        }
     }
 }

--- a/src/Api/Controllers/StringStoreController.php
+++ b/src/Api/Controllers/StringStoreController.php
@@ -5,6 +5,7 @@ namespace FoF\Linguist\Api\Controllers;
 use FoF\Linguist\Api\Serializers\StringSerializer;
 use FoF\Linguist\Repositories\StringRepository;
 use Flarum\Api\Controller\AbstractCreateController;
+use Flarum\Http\RequestUtil;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -25,7 +26,7 @@ class StringStoreController extends AbstractCreateController
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         $attributes = Arr::get($request->getParsedBody(), 'data.attributes', []);
 

--- a/src/Api/Controllers/StringUpdateController.php
+++ b/src/Api/Controllers/StringUpdateController.php
@@ -5,6 +5,7 @@ namespace FoF\Linguist\Api\Controllers;
 use FoF\Linguist\Api\Serializers\StringSerializer;
 use FoF\Linguist\Repositories\StringRepository;
 use Flarum\Api\Controller\AbstractShowController;
+use Flarum\Http\RequestUtil;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -25,7 +26,7 @@ class StringUpdateController extends AbstractShowController
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        RequestUtil::getActor($request)->assertAdmin();
 
         $id = Arr::get($request->getQueryParams(), 'id');
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Adds the possibility to filter string keys with a `filter[prefix]=...` parameter when using the API. Also, to be more flexible, one can set a permission to allow other users (even guests) to view string keys.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
